### PR TITLE
use Cabal-3.12

### DIFF
--- a/all-cabal-tool.cabal
+++ b/all-cabal-tool.cabal
@@ -25,7 +25,7 @@ library
                      , Stackage.Package.Metadata
                      , Stackage.Package.Metadata.Types
                      , Stackage.Package.Update
-  build-depends:       Cabal >= 2.0
+  build-depends:       Cabal >= 3.12
                      , aeson
                      , base
                      , byteable

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,9 @@
-resolver: lts-22.4
+resolver: lts-22.44
 extra-deps:
 - github: commercialhaskell/hit
   commit: 1546b0c2a2f56e28b9ed5a1c5bf1a10adcad8b6c
 - patience-0.3@sha256:fe3a2c5b1ac4d3425bad3d1ee0b6bb529b6e74ab41151f8526f26fc8dfa1206b,1252
+- Cabal-3.12.1.0
+- Cabal-syntax-3.12.1.0
 nix:
   packages: [ zlib git ]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -22,9 +22,23 @@ packages:
       size: 368
   original:
     hackage: patience-0.3@sha256:fe3a2c5b1ac4d3425bad3d1ee0b6bb529b6e74ab41151f8526f26fc8dfa1206b,1252
+- completed:
+    hackage: Cabal-3.12.1.0@sha256:08be296ddd941b3f9be4bd125fbb3e6857f5c707b8d10464f6f1d30c91ca3e5f,13551
+    pantry-tree:
+      sha256: a509c8164a9682e2cbd080ef8446164fbe11a9c5c0f88b61f41094a8167e6a04
+      size: 11798
+  original:
+    hackage: Cabal-3.12.1.0
+- completed:
+    hackage: Cabal-syntax-3.12.1.0@sha256:6dbb06fb08ff77520947fb4c1ef281c9cea5b8dc7fd9a41ad62273fa916cf4b2,7407
+    pantry-tree:
+      sha256: 62e4b1bbdf7fe7d5259f45811e6fd0131823a10a8ec8c5eaf25370d444ac263a
+      size: 11051
+  original:
+    hackage: Cabal-syntax-3.12.1.0
 snapshots:
 - completed:
-    sha256: 8b211c5a6aad3787e023dfddaf7de7868968e4f240ecedf14ad1c5b2199046ca
-    size: 714097
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/4.yaml
-  original: lts-22.4
+    sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9
+    size: 721141
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/44.yaml
+  original: lts-22.44


### PR DESCRIPTION
This builds with Cabal-3.12.

It seems to work though locally I ran into local amazonka linking issue with missing symlinks,
so I can't fully confirm it builds yet. (With latest fedora I system-fileio fails to build with gcc15.)